### PR TITLE
feat(nx-cloud): set up nx workspace

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -1,0 +1,51 @@
+# Sample workflow for building and deploying a Jekyll site to GitHub Pages
+name: Deploy Jekyll with GitHub Pages dependencies preinstalled
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["master"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./
+          destination: ./_site
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/apps/remixdesktop/package.json
+++ b/apps/remixdesktop/package.json
@@ -53,7 +53,7 @@
     "byline": "^5.0.0",
     "chokidar": "^4.0.3",
     "express": "^4.21.1",
-    "isomorphic-git": "^1.24.2",
+    "isomorphic-git": "^1.30.1",
     "node-pty": "^1.0.0",
     "semver": "^7.6.1"
   },

--- a/apps/remixdesktop/package.json
+++ b/apps/remixdesktop/package.json
@@ -47,7 +47,7 @@
     "@remixproject/plugin": "0.3.208",
     "@remixproject/plugin-api": "^0.3.38",
     "@remixproject/plugin-electron": "0.3.41",
-    "@vscode/ripgrep": "^1.15.6",
+    "@vscode/ripgrep": "^1.15.11",
     "add": "^2.0.6",
     "axios": "^1.8.3",
     "byline": "^5.0.0",

--- a/apps/remixdesktop/yarn.lock
+++ b/apps/remixdesktop/yarn.lock
@@ -907,13 +907,14 @@
   dependencies:
     "@types/node" "*"
 
-"@vscode/ripgrep@^1.15.6":
-  version "1.15.6"
-  resolved "https://registry.npmjs.org/@vscode/ripgrep/-/ripgrep-1.15.6.tgz"
-  integrity sha512-mCtfHqZ/g+75qDDeIPB9ST1xyJDaJornaSujuRKkB0SMZ6FMVtuKUdvvvOITR+DcKo5KOwUVuOUUpt75jOY+Yw==
+"@vscode/ripgrep@^1.15.11":
+  version "1.15.11"
+  resolved "https://registry.yarnpkg.com/@vscode/ripgrep/-/ripgrep-1.15.11.tgz#31d49e8edae86cd6bab3017f1b2088bdb48dfc4e"
+  integrity sha512-G/VqtA6kR50mJkIH4WA+I2Q78V5blovgPPq0VPYM0QIRp57lYMkdV+U9VrY80b3AvaC72A1z8STmyxc8ZKiTsw==
   dependencies:
     https-proxy-agent "^7.0.2"
     proxy-from-env "^1.1.0"
+    yauzl "^2.9.2"
 
 "@xmldom/xmldom@^0.8.8":
   version "0.8.10"
@@ -5603,7 +5604,7 @@ yarn@^1.22.21:
   resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.22.21.tgz#1959a18351b811cdeedbd484a8f86c3cc3bbaf72"
   integrity sha512-ynXaJsADJ9JiZ84zU25XkPGOvVMmZ5b7tmTSpKURYwgELdjucAOydqIOrOfTxVYcNXe91xvLZwcRh68SR3liCg==
 
-yauzl@^2.10.0:
+yauzl@^2.10.0, yauzl@^2.9.2:
   version "2.10.0"
   resolved "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz"
   integrity sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==

--- a/apps/remixdesktop/yarn.lock
+++ b/apps/remixdesktop/yarn.lock
@@ -1147,10 +1147,10 @@ async-limiter@~1.0.0:
   resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.1.tgz#dd379e94f0db8310b08291f9d64c3209766617fd"
   integrity sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==
 
-async-lock@^1.1.0:
-  version "1.4.0"
-  resolved "https://registry.npmjs.org/async-lock/-/async-lock-1.4.0.tgz"
-  integrity sha512-coglx5yIWuetakm3/1dsX9hxCNox22h7+V80RQOu2XUUMidtArxKoZoOtHUPuR84SycKTXzgGzAUR5hJxujyJQ==
+async-lock@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/async-lock/-/async-lock-1.4.1.tgz#56b8718915a9b68b10fce2f2a9a3dddf765ef53f"
+  integrity sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==
 
 async@^3.2.3:
   version "3.2.5"
@@ -3318,18 +3318,19 @@ isexe@^2.0.0:
   resolved "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
   integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
 
-isomorphic-git@^1.24.2:
-  version "1.24.2"
-  resolved "https://registry.npmjs.org/isomorphic-git/-/isomorphic-git-1.24.2.tgz"
-  integrity sha512-J3TU97JENWUnOgpVMwaRP9a3OQXJq/8fCIzA4yrJ7+ko1IPJwXCYeA69CeC8GtHeBVhcOQrbZGw6fpIpz54Vpw==
+isomorphic-git@^1.30.1:
+  version "1.30.1"
+  resolved "https://registry.yarnpkg.com/isomorphic-git/-/isomorphic-git-1.30.1.tgz#7706fca07a0039c47e49b7e5b4c12a3ad24f7e3a"
+  integrity sha512-eWBlPIPDOctGY/bTUc/whs6EZ8YvnG1H2kOjTCJ/AkvBWUzODXcfulhpiA8Y4Px9e+bRYYkifE5fSE8FcRk8Ew==
   dependencies:
-    async-lock "^1.1.0"
+    async-lock "^1.4.1"
     clean-git-ref "^2.0.1"
     crc-32 "^1.2.0"
     diff3 "0.0.3"
     ignore "^5.1.4"
     minimisted "^2.0.0"
     pako "^1.0.10"
+    path-browserify "^1.0.1"
     pify "^4.0.1"
     readable-stream "^3.4.0"
     sha.js "^2.4.9"
@@ -4043,6 +4044,11 @@ parseurl@~1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
   integrity sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==
+
+path-browserify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-1.0.1.tgz#d98454a9c3753d5790860f16f68867b9e46be1fd"
+  integrity sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==
 
 path-is-absolute@^1.0.0:
   version "1.0.1"

--- a/libs/ghaction-helper/package.json
+++ b/libs/ghaction-helper/package.json
@@ -27,7 +27,7 @@
     "@ethereum-waffle/chai": "^3.4.4",
     "@remix-project/remix-simulator": "^0.2.50",
     "chai": "^5.1.2",
-    "ethers": "^5.7.2",
+    "ethers": "^6.13.6",
     "web3": "^4.1.1"
   },
   "types": "./src/index.d.ts",

--- a/libs/remix-lib/package.json
+++ b/libs/remix-lib/package.json
@@ -20,7 +20,7 @@
     "@ethereumjs/util": "9.0.3",
     "async": "^2.1.2",
     "create-hash": "^1.2.0",
-    "ethers": "^5.7.2",
+    "ethers": "^6.13.6",
     "ethjs-util": "^0.1.6",
     "events": "^3.0.0",
     "from-exponential": "1.1.1",

--- a/libs/remix-lib/package.json
+++ b/libs/remix-lib/package.json
@@ -25,7 +25,7 @@
     "events": "^3.0.0",
     "from-exponential": "1.1.1",
     "rlp": "^3.0.0",
-    "solc": "^0.7.4",
+    "solc": "^0.8.29",
     "string-similarity": "^4.0.4",
     "web3": "^4.1.1",
     "web3-validator": "^2.0.0"

--- a/libs/remix-tests/package.json
+++ b/libs/remix-tests/package.json
@@ -53,7 +53,7 @@
     "colors": "1.4.0",
     "commander": "^9.4.1",
     "deep-equal": "^1.0.1",
-    "ethers": "^5.4.2",
+    "ethers": "^6.13.6",
     "ethjs-util": "^0.1.6",
     "express-ws": "^4.0.0",
     "merge": "^2.1.1",

--- a/libs/remix-url-resolver/package.json
+++ b/libs/remix-url-resolver/package.json
@@ -24,7 +24,7 @@
   "license": "MIT",
   "dependencies": {
     "@erebos/bzz-node": "^0.13.0",
-    "axios": "1.8.3",
+    "axios": "1.8.4",
     "semver": "^7.5.4",
     "url": "^0.11.0",
     "valid-url": "^1.0.9"

--- a/libs/remixd/package.json
+++ b/libs/remixd/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@remixproject/plugin": "0.3.33",
     "@remixproject/plugin-api": "0.3.33",
-    "@remixproject/plugin-utils": "0.3.33",
+    "@remixproject/plugin-utils": "0.3.208",
     "@remixproject/plugin-ws": "0.3.33",
     "@remix-project/remix-solidity": "^0.5.36",
     "axios": "1.8.3",


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace

This commit sets up Nx Cloud for your Nx workspace, enabling distributed caching and the Nx Cloud GitHub integration for fast CI and improved developer experience.

You can access your Nx Cloud workspace by going to
https://cloud.nx.app/orgs/665901a7680f93354fee8f81/workspaces/6738914be7757bb786a40c74

**Note:** This commit attempts to maintain formatting of the nx.json file, however you may need to correct formatting by running an nx format command and committing the changes.

## Summary by Sourcery

Set up Nx Cloud workspace and update project dependencies

New Features:
- Integrated Nx Cloud workspace for distributed caching and GitHub integration

Enhancements:
- Upgraded various npm packages to latest versions

CI:
- Added Jekyll GitHub Pages deployment workflow

Chores:
- Updated package dependencies across multiple libraries and applications