### PR TITLE
update solc

### DIFF
--- a/libs/remix-debug/package.json
+++ b/libs/remix-debug/package.json
@@ -50,9 +50,9 @@
     "@babel/preset-es2015": "latest",
     "@babel/preset-es2017": "latest",
     "@babel/preset-stage-0": "^7.0.0",
-    "babel-eslint": "^7.1.1",
+    "babel-eslint": "^10.1.0",
     "babelify": "^10.0.0",
-    "solc": "^0.7.4",
+    "solc": "^0.8.12",
     "tape": "^4.6.0"
   },
   "publishConfig": {

--- a/libs/remix-simulator/package.json
+++ b/libs/remix-simulator/package.json
@@ -48,9 +48,9 @@
     "@babel/preset-es2015": "latest",
     "@babel/preset-es2017": "latest",
     "@babel/preset-stage-0": "^7.0.0",
-    "babel-eslint": "^7.1.1",
+    "babel-eslint": "^10.1.0",
     "babelify": "^10.0.0",
-    "mocha": "^5.2.0"
+    "mocha": "^11.0.1"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary by Sourcery

Update Solidity compiler (solc) version in remix-debug package dependencies

Enhancements:
- Upgrade solc from version 0.7.4 to 0.8.12

Chores:
- Upgrade babel-eslint from version 7.1.1 to 10.1.0