### PR TITLE
Potential fix for code scanning alert no. 30: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/service-checker.yml
+++ b/.github/workflows/service-checker.yml
@@ -5,6 +5,9 @@ on:
     - cron: "0 0-23/4 * * 0-6"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   pr-reviews-reminder:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/remix-project/security/code-scanning/30](https://github.com/Dargon789/remix-project/security/code-scanning/30)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow uses a third-party action (`Aniket-Engg/pr-reviews-reminder-action@master`), we will assume it only requires read access to repository contents unless its documentation specifies otherwise. The `permissions` block will be added at the root level of the workflow to apply to all jobs, ensuring that the `GITHUB_TOKEN` has only `contents: read` permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Address code scanning alert by restricting the GITHUB_TOKEN permissions in the service-checker workflow.

Bug Fixes:
- Fix code scanning alert by adding a permissions block to limit GITHUB_TOKEN contents access to read

CI:
- Add root-level permissions block in .github/workflows/service-checker.yml to grant only contents: read