### PR TITLE
Potential fix for code scanning alert no. 29: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rebase-pull-requests.yml
+++ b/.github/workflows/rebase-pull-requests.yml
@@ -1,3 +1,6 @@
+permissions:
+  contents: read
+  pull-requests: write
 name: Rebase Pull Requests
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/remix-project/security/code-scanning/29](https://github.com/Dargon789/remix-project/security/code-scanning/29)

To fix the problem, explicit permissions need to be defined for the workflow or job. Since the workflow is named "Rebase Pull Requests" and appears to deal with pull requests, the necessary permissions likely include `contents: read` (to access repository contents) and `pull-requests: write` (to modify or rebase pull requests). These permissions are sufficient for the workflow to perform its intended tasks while adhering to the principle of least privilege.

The `permissions` block should be added at the root of the workflow file, applying to all jobs, as this is the simplest and most maintainable approach.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Add explicit permissions to the 'Rebase Pull Requests' GitHub Actions workflow to satisfy least privilege requirements and fix a code scanning alert.

Bug Fixes:
- Fix code scanning alert no. 29 by defining workflow permissions

CI:
- Add permissions block with contents: read and pull-requests: write to the workflow